### PR TITLE
UI polish and wide radar composite for wide terminals

### DIFF
--- a/src/api/jma.rs
+++ b/src/api/jma.rs
@@ -623,7 +623,17 @@ impl WeatherProvider for Jma {
         Self::set_language(self, lang);
     }
 
-    async fn radar(&self, lat: f64, lon: f64, zoom: u8, time_offset: i32) -> Result<RadarGrid> {
+    async fn radar(
+        &self,
+        lat: f64,
+        lon: f64,
+        zoom: u8,
+        time_offset: i32,
+        aspect: f64,
+    ) -> Result<RadarGrid> {
+        // 横方向のタイル取得範囲 (dx) は ±2 固定なので、view が
+        // はみ出さない範囲にアスペクト比をクランプする
+        let aspect = aspect.clamp(1.0, 2.4);
         // ナウキャストのエンドポイント:
         //   - targetTimes_N1.json : 過去・現在の実況 (basetime == validtime)
         //   - targetTimes_N2.json : 未来予測 (basetime 共通、validtime が +5..+60 分)
@@ -696,18 +706,19 @@ impl WeatherProvider for Jma {
         // 下流コードと変数名を揃えるためのエイリアス
         let z = mz;
 
-        // ---- 3x3 タイル × 4 種類を並列取得 ----
+        // ---- 5x3 タイル × 4 種類を並列取得 ----
         // - 雨雲 grid（数値、Brailleフォールバック用 + max計算用）
         // - 地図ドット（Brailleフォールバック用、現状は使わない予定）
         // - 雨雲 PNG画像（Kitty graphics 用）
         // - 地図 PNG画像（Kitty graphics 用）
-        let mut rain_fetches = Vec::with_capacity(9);
-        let mut map_dot_fetches = Vec::with_capacity(9);
-        let mut rain_img_fetches = Vec::with_capacity(9);
-        let mut map_img_fetches = Vec::with_capacity(9);
-        // 地図は map_z で 3x3、雨雲は rain_z で 3x3。
+        // 横長アスペクト対応のため横方向は ±2 タイル取得する
+        let mut rain_fetches = Vec::with_capacity(15);
+        let mut map_dot_fetches = Vec::with_capacity(15);
+        let mut rain_img_fetches = Vec::with_capacity(15);
+        let mut map_img_fetches = Vec::with_capacity(15);
+        // 地図は map_z で 5x3、雨雲は rain_z で 5x3。
         for dy in -1i32..=1 {
-            for dx in -1i32..=1 {
+            for dx in -2i32..=2 {
                 // 地図側 (map_z)
                 let mtx = cx as i32 + dx;
                 let mty = cy as i32 + dy;
@@ -783,7 +794,8 @@ impl WeatherProvider for Jma {
         // 雨雲は z=10 までしか無いので、map_z>10 の時は雨雲のピクセル解像度が見える。
         let (lat_n_c, lon_w_c) = tile_to_lonlat(map_z, cx, cy);
         let (lat_s_c, lon_e_c) = tile_to_lonlat(map_z, cx + 1, cy + 1);
-        let half_lon = (lon_e_c - lon_w_c) / 2.0;
+        // 横方向はアスペクト比のぶんだけ view を広げる（縦はタイル1枚分のまま）
+        let half_lon = (lon_e_c - lon_w_c) / 2.0 * aspect;
         let half_lat = (lat_n_c - lat_s_c) / 2.0;
         let view_lon_w = lon - half_lon;
         let view_lon_e = lon + half_lon;
@@ -803,7 +815,7 @@ impl WeatherProvider for Jma {
                 let (_zz, tx, ty) = lonlat_to_tile(v_lon, v_lat, z);
                 let dx = tx as i32 - cx as i32;
                 let dy = ty as i32 - cy as i32;
-                if !(-1..=1).contains(&dx) || !(-1..=1).contains(&dy) {
+                if !(-2..=2).contains(&dx) || !(-1..=1).contains(&dy) {
                     continue;
                 }
                 // タイル内のピクセル位置（左上= (lat_n_t, lon_w_t)）
@@ -826,6 +838,7 @@ impl WeatherProvider for Jma {
 
         // ---- Kitty graphics 用合成画像を生成 ----
         let composite_image = build_composite_image(
+            aspect,
             map_z,
             cx,
             cy,
@@ -854,10 +867,11 @@ impl WeatherProvider for Jma {
     }
 }
 
-/// 9 タイルを地理座標系で 768x768 のキャンバスに貼り合わせ、
+/// 5x3 タイルを地理座標系のキャンバスに貼り合わせ、
 /// ユーザー位置を中心にした view 範囲をクロップ。
 /// 雨雲は地図の上に alpha blend で重ねる。
 fn build_composite_image(
+    aspect: f64,
     map_z: u8,
     map_cx: u32,
     map_cy: u32,
@@ -875,11 +889,11 @@ fn build_composite_image(
 ) -> Option<image::DynamicImage> {
     use image::Rgba;
 
-    // 出力解像度。view 範囲は地理座標で「ほぼ正方形」(タイル1枚分=lat/lon 同程度の度差)
-    // なので、ピクセル比も正方形にしないと画像が縦/横に潰れて見える。
+    // 出力解像度。view の地理的な縦横比（≒aspect）とピクセル比を一致させないと
+    // 画像が縦/横に潰れて見える。
     // 表示パネルの幅をレイアウト側で「画像のアスペクト比に合わせる」ことで歪み回避。
-    let out_w: u32 = 1024;
     let out_h: u32 = 1024;
+    let out_w: u32 = ((out_h as f64 * aspect).round() as u32).clamp(1024, 2560);
 
     // 9 タイル合成キャンバスは「中心タイル + 周辺8タイル」= 3 タイル幅 × 3 タイル高
     // タイル1枚=256ピクセル → 合成は 768x768
@@ -899,7 +913,7 @@ fn build_composite_image(
             let (_, mtx, mty) = lonlat_to_tile(v_lon, v_lat, map_z);
             let mdx = mtx as i32 - map_cx as i32;
             let mdy = mty as i32 - map_cy as i32;
-            if (-1..=1).contains(&mdx) && (-1..=1).contains(&mdy) {
+            if (-2..=2).contains(&mdx) && (-1..=1).contains(&mdy) {
                 if let Some(map) = map_imgs.get(&(mdx, mdy)) {
                     let (lat_n_t, lon_w_t) = tile_to_lonlat(map_z, mtx, mty);
                     let (lat_s_t, lon_e_t) = tile_to_lonlat(map_z, mtx + 1, mty + 1);
@@ -912,7 +926,7 @@ fn build_composite_image(
             let (_, rtx, rty) = lonlat_to_tile(v_lon, v_lat, rain_z);
             let rdx = rtx as i32 - rain_cx as i32;
             let rdy = rty as i32 - rain_cy as i32;
-            if (-1..=1).contains(&rdx) && (-1..=1).contains(&rdy) {
+            if (-2..=2).contains(&rdx) && (-1..=1).contains(&rdy) {
                 if let Some(rain) = rain_imgs.get(&(rdx, rdy)) {
                     let (lat_n_t, lon_w_t) = tile_to_lonlat(rain_z, rtx, rty);
                     let (lat_s_t, lon_e_t) = tile_to_lonlat(rain_z, rtx + 1, rty + 1);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -106,7 +106,16 @@ pub trait WeatherProvider: Send + Sync {
     async fn daily(&self, lat: f64, lon: f64) -> Result<Vec<DailyPoint>>;
     /// `time_offset` は targetTimes 配列内での相対インデックス。
     /// 0=最新（現在）、負=過去、正=未来予測。範囲外は最寄りにクランプ。
-    async fn radar(&self, lat: f64, lon: f64, zoom: u8, time_offset: i32) -> Result<RadarGrid>;
+    /// `aspect` は合成画像の横/縦比。1.0 で正方形、>1 で横長
+    /// （ワイドターミナルでレーダーパネルを使い切るため）。
+    async fn radar(
+        &self,
+        lat: f64,
+        lon: f64,
+        zoom: u8,
+        time_offset: i32,
+        aspect: f64,
+    ) -> Result<RadarGrid>;
 
     /// 背景地図スタイルの切替（JMA だけが対応、Open-Meteo は無視）
     fn set_map_style(&self, _style: crate::config::MapStyle) {}

--- a/src/api/open_meteo.rs
+++ b/src/api/open_meteo.rs
@@ -322,7 +322,15 @@ impl WeatherProvider for OpenMeteo {
         Ok(out)
     }
 
-    async fn radar(&self, lat: f64, lon: f64, zoom: u8, _time_offset: i32) -> Result<RadarGrid> {
+    async fn radar(
+        &self,
+        lat: f64,
+        lon: f64,
+        zoom: u8,
+        _time_offset: i32,
+        aspect: f64,
+    ) -> Result<RadarGrid> {
+        let aspect = aspect.clamp(1.0, 2.4);
         // 外国でもカラー地図 + 雨雲を表示するため、JMA と同様に画像合成を行う。
         // 違いは:
         //   - 雨雲: Open-Meteo の precipitation を多地点で取得 (32x16 grid)
@@ -333,7 +341,8 @@ impl WeatherProvider for OpenMeteo {
         // view 範囲 = map_z タイル1枚分の地理サイズ（ユーザー位置を中央に）
         let (lat_n_c, lon_w_c) = tile_to_lonlat(map_z, mcx, mcy);
         let (lat_s_c, lon_e_c) = tile_to_lonlat(map_z, mcx + 1, mcy + 1);
-        let half_lon = (lon_e_c - lon_w_c) / 2.0;
+        // 横方向はアスペクト比のぶんだけ view を広げる（縦はタイル1枚分のまま）
+        let half_lon = (lon_e_c - lon_w_c) / 2.0 * aspect;
         let half_lat = (lat_n_c - lat_s_c) / 2.0;
         let view_lon_w = lon - half_lon;
         let view_lon_e = lon + half_lon;
@@ -392,10 +401,10 @@ impl WeatherProvider for OpenMeteo {
             }
         }
 
-        // ---- 地図タイルを 3x3 並列取得 ----
-        let mut map_fetches = Vec::with_capacity(9);
+        // ---- 地図タイルを 5x3 並列取得（横長アスペクト対応で横 ±2）----
+        let mut map_fetches = Vec::with_capacity(15);
         for dy in -1i32..=1 {
-            for dx in -1i32..=1 {
+            for dx in -2i32..=2 {
                 let tx = mcx as i32 + dx;
                 let ty = mcy as i32 + dy;
                 if tx < 0 || ty < 0 {
@@ -419,6 +428,7 @@ impl WeatherProvider for OpenMeteo {
 
         // ---- 合成画像生成 ----
         let composite_image = build_composite_image_om(
+            aspect,
             map_z,
             mcx,
             mcy,
@@ -456,6 +466,7 @@ impl WeatherProvider for OpenMeteo {
 /// 地図サンプルは JMA と同じヘルパー (sample_bilinear) を使う。
 #[allow(clippy::too_many_arguments)]
 fn build_composite_image_om(
+    aspect: f64,
     map_z: u8,
     map_cx: u32,
     map_cy: u32,
@@ -471,8 +482,8 @@ fn build_composite_image_om(
 ) -> Option<image::DynamicImage> {
     use image::Rgba;
 
-    let out_w: u32 = 1024;
     let out_h: u32 = 1024;
+    let out_w: u32 = ((out_h as f64 * aspect).round() as u32).clamp(1024, 2560);
     let mut canvas = image::RgbaImage::from_pixel(out_w, out_h, Rgba([255, 255, 255, 255]));
 
     let grid_h = rain_grid.len();
@@ -516,7 +527,7 @@ fn build_composite_image_om(
             let (_, mtx, mty) = lonlat_to_tile(v_lon, v_lat, map_z);
             let mdx = mtx as i32 - map_cx as i32;
             let mdy = mty as i32 - map_cy as i32;
-            if (-1..=1).contains(&mdx) && (-1..=1).contains(&mdy) {
+            if (-2..=2).contains(&mdx) && (-1..=1).contains(&mdy) {
                 if let Some(map) = map_imgs.get(&(mdx, mdy)) {
                     let (lat_n_t, lon_w_t) = tile_to_lonlat(map_z, mtx, mty);
                     let (lat_s_t, lon_e_t) = tile_to_lonlat(map_z, mtx + 1, mty + 1);

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,9 @@ pub struct AppState {
     /// 雨雲レーダーの取得中フラグ。spawn_radar で true、Msg::Radar 受信で false。
     /// 時刻スクラブやズーム中に「いま処理中」を UI で示すために使う。
     pub radar_loading: bool,
+    /// 合成画像に要求するアスペクト比（横/縦）。端末サイズから計算し、
+    /// ワイドターミナルではレーダーを横長にしてパネルを使い切る。
+    pub radar_aspect: f64,
     pub last_error: Option<String>,
     pub quit: bool,
 }
@@ -228,6 +231,11 @@ pub async fn run(args: Args) -> Result<()> {
         }
     };
 
+    // 初回フェッチ用のアスペクト比は起動時の端末サイズから計算する
+    let (term_w, term_h) = crossterm::terminal::size().unwrap_or((120, 40));
+    let font_size = image_picker.as_ref().map(|p| p.font_size());
+    let radar_aspect = crate::ui::desired_radar_aspect(term_w, term_h, font_size);
+
     // 5) AppState を作って TUI を起動
     let mut state = AppState {
         config,
@@ -245,6 +253,7 @@ pub async fn run(args: Args) -> Result<()> {
         show_help: false,
         spinner_frame: 0,
         radar_loading: false,
+        radar_aspect,
         last_error: None,
         quit: false,
     };
@@ -259,6 +268,7 @@ pub async fn run(args: Args) -> Result<()> {
         provider.clone(),
         state.config.clone(),
         state.radar_time_offset,
+        state.radar_aspect,
         tx.clone(),
     );
     spawn_map_load(tx.clone());
@@ -316,7 +326,7 @@ pub async fn run(args: Args) -> Result<()> {
                     sleep(Duration::from_secs(60 * 60 * 24)).await;
                 }
             } => {
-                spawn_fetch(provider.clone(), state.config.clone(), state.radar_time_offset, tx.clone());
+                spawn_fetch(provider.clone(), state.config.clone(), state.radar_time_offset, state.radar_aspect, tx.clone());
             }
             // 雨雲アニメーション (playing 中のみ反映)
             _ = anim_tick.tick() => {
@@ -326,7 +336,7 @@ pub async fn run(args: Args) -> Result<()> {
                         state.radar_time_offset = -6;
                     }
                     state.radar_loading = true;
-                    spawn_radar(provider.clone(), state.config.clone(), state.radar_time_offset, tx.clone());
+                    spawn_radar(provider.clone(), state.config.clone(), state.radar_time_offset, state.radar_aspect, tx.clone());
                 }
             }
             // スピナー進行: 何かしらロード中 or splash 中なら再描画
@@ -397,6 +407,24 @@ fn handle_event(
     provider: &Arc<dyn WeatherProvider>,
     tx: &mpsc::UnboundedSender<Msg>,
 ) -> bool {
+    // リサイズ時: 理想アスペクト比が大きく変わったらレーダーを再取得する
+    // （ドラッグ中のイベント連発は radar_loading ガードで間引く）
+    if let Event::Resize(w, h) = ev {
+        let font = state.image_picker.as_ref().map(|p| p.font_size());
+        let desired = crate::ui::desired_radar_aspect(w, h, font);
+        if (desired - state.radar_aspect).abs() > 0.15 && !state.radar_loading {
+            state.radar_aspect = desired;
+            state.radar_loading = true;
+            spawn_radar(
+                provider.clone(),
+                state.config.clone(),
+                state.radar_time_offset,
+                state.radar_aspect,
+                tx.clone(),
+            );
+        }
+        return true;
+    }
     let Event::Key(k) = ev else { return false };
     if k.kind != KeyEventKind::Press {
         return false;
@@ -427,6 +455,7 @@ fn handle_event(
                 provider.clone(),
                 state.config.clone(),
                 state.radar_time_offset,
+                state.radar_aspect,
                 tx.clone(),
             );
         }
@@ -438,6 +467,7 @@ fn handle_event(
                 provider.clone(),
                 state.config.clone(),
                 state.radar_time_offset,
+                state.radar_aspect,
                 tx.clone(),
             );
         }
@@ -448,6 +478,7 @@ fn handle_event(
                 provider.clone(),
                 state.config.clone(),
                 state.radar_time_offset,
+                state.radar_aspect,
                 tx.clone(),
             );
         }
@@ -464,6 +495,7 @@ fn handle_event(
                 provider.clone(),
                 state.config.clone(),
                 state.radar_time_offset,
+                state.radar_aspect,
                 tx.clone(),
             );
         }
@@ -474,6 +506,7 @@ fn handle_event(
                 provider.clone(),
                 state.config.clone(),
                 state.radar_time_offset,
+                state.radar_aspect,
                 tx.clone(),
             );
         }
@@ -490,6 +523,7 @@ fn handle_event(
                 provider.clone(),
                 state.config.clone(),
                 state.radar_time_offset,
+                state.radar_aspect,
                 tx.clone(),
             );
         }
@@ -508,13 +542,20 @@ fn shift_location(
     state.config.location.longitude += dlon;
     state.config.location.latitude += dlat;
     state.radar_loading = true;
-    spawn_radar(provider, state.config.clone(), state.radar_time_offset, tx);
+    spawn_radar(
+        provider,
+        state.config.clone(),
+        state.radar_time_offset,
+        state.radar_aspect,
+        tx,
+    );
 }
 
 fn spawn_fetch(
     provider: Arc<dyn WeatherProvider>,
     cfg: Config,
     time_offset: i32,
+    aspect: f64,
     tx: mpsc::UnboundedSender<Msg>,
 ) {
     let lat = cfg.location.latitude;
@@ -568,7 +609,7 @@ fn spawn_fetch(
         let p = provider;
         let tx = tx.clone();
         tokio::spawn(async move {
-            match p.radar(lat, lon, zoom, time_offset).await {
+            match p.radar(lat, lon, zoom, time_offset, aspect).await {
                 Ok(r) => {
                     let _ = tx.send(Msg::Radar(r));
                 }
@@ -584,13 +625,14 @@ fn spawn_radar(
     provider: Arc<dyn WeatherProvider>,
     cfg: Config,
     time_offset: i32,
+    aspect: f64,
     tx: mpsc::UnboundedSender<Msg>,
 ) {
     let lat = cfg.location.latitude;
     let lon = cfg.location.longitude;
     let zoom = cfg.radar.zoom;
     tokio::spawn(async move {
-        match provider.radar(lat, lon, zoom, time_offset).await {
+        match provider.radar(lat, lon, zoom, time_offset, aspect).await {
             Ok(r) => {
                 let _ = tx.send(Msg::Radar(r));
             }

--- a/src/ui/current.rs
+++ b/src/ui/current.rs
@@ -48,35 +48,40 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
             ),
         ]));
         lines.push(Line::from(""));
+        // 気温をヒーロー表示（温度に応じた色で強調）
         lines.push(Line::from(vec![
+            Span::raw("  "),
             Span::styled(
-                format!("  {}  ", s.temp),
-                Style::default().fg(theme::SUBTLE),
-            ),
-            Span::styled(
-                format!("{:>5.1} ℃", cw.temperature_c),
+                format!("{:.1}", cw.temperature_c),
                 Style::default()
-                    .fg(theme::TEMP)
+                    .fg(theme::temp_color(cw.temperature_c))
                     .add_modifier(Modifier::BOLD),
             ),
+            Span::styled(
+                " ℃",
+                Style::default().fg(theme::temp_color(cw.temperature_c)),
+            ),
         ]));
+        lines.push(Line::from(""));
+        // 湿度・風は 1 行にまとめてコンパクトに
+        let mut detail: Vec<Span> = vec![Span::raw("  ")];
         if let Some(h) = cw.humidity_pct {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {}  ", s.humidity),
-                    Style::default().fg(theme::SUBTLE),
-                ),
-                Span::styled(format!("{:>5.0} %", h), Style::default().fg(theme::RAIN)),
-            ]));
+            detail.push(Span::raw("💧"));
+            detail.push(Span::styled(
+                format!(" {:.0}%", h),
+                Style::default().fg(theme::RAIN),
+            ));
+            detail.push(Span::raw("   "));
         }
         if let Some(w) = cw.wind_speed_ms {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {}  ", s.wind),
-                    Style::default().fg(theme::SUBTLE),
-                ),
-                Span::styled(format!("{:>5.1} m/s", w), Style::default().fg(theme::FG)),
-            ]));
+            detail.push(Span::raw("🍃"));
+            detail.push(Span::styled(
+                format!(" {:.1}m/s", w),
+                Style::default().fg(theme::FG),
+            ));
+        }
+        if detail.len() > 1 {
+            lines.push(Line::from(detail));
         }
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(

--- a/src/ui/hourly.rs
+++ b/src/ui/hourly.rs
@@ -27,9 +27,17 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
         return;
     }
 
+    // 現在時刻を含む時間帯から表示（過去分は出さない）
+    let now = chrono::Local::now();
+    let start = state
+        .hourly
+        .iter()
+        .position(|p| p.time + chrono::Duration::hours(1) > now)
+        .unwrap_or(0);
     // 表示数は端末幅から逆算（最大 48 時間）
     let take = (inner.width as usize).saturating_sub(4).min(48).max(8);
-    let points: Vec<&crate::api::HourlyPoint> = state.hourly.iter().take(take).collect();
+    let points: Vec<&crate::api::HourlyPoint> =
+        state.hourly.iter().skip(start).take(take).collect();
 
     // 気温折れ線データ
     let temp_data: Vec<(f64, f64)> = points
@@ -82,7 +90,10 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
         x_labels.push(Span::styled(text, Style::default().fg(theme::SUBTLE)));
     }
 
+    // Chart は自身の style で領域を塗りつぶすため、bg を明示しないと
+    // ブロックで塗った背景がリセットされ、半透明ターミナルでは壁紙が透ける
     let chart = Chart::new(datasets)
+        .style(Style::default().bg(theme::BG))
         .x_axis(
             Axis::default()
                 .style(Style::default().fg(theme::SUBTLE))
@@ -94,8 +105,14 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
                 .style(Style::default().fg(theme::SUBTLE))
                 .bounds([temp_min - pad, temp_max + pad])
                 .labels(vec![
-                    Span::raw(format!("{:.0}", temp_min - pad)),
-                    Span::raw(format!("{:.0}", temp_max + pad)),
+                    Span::styled(
+                        format!("{:.0}°", temp_min - pad),
+                        Style::default().fg(theme::temp_color(temp_min)),
+                    ),
+                    Span::styled(
+                        format!("{:.0}°", temp_max + pad),
+                        Style::default().fg(theme::temp_color(temp_max)),
+                    ),
                 ]),
         );
 
@@ -111,51 +128,57 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
         .iter()
         .any(|p| p.precipitation_prob_pct.is_some_and(|v| v > 0.0));
 
-    let (bars, label_text) = if has_mm {
+    // 降水量は時間ごとに強度が違うので、1文字ずつ色を変えた Span にする
+    let (bar_spans, label_text) = if has_mm {
         let max_p = points
             .iter()
             .map(|p| p.precipitation_mm)
             .fold(0.0_f64, f64::max)
             .max(1.0);
-        let bars: String = points
+        let spans: Vec<Span> = points
             .iter()
             .map(|p| {
                 if p.precipitation_mm <= 0.0 {
-                    ' '
+                    Span::raw(" ")
                 } else {
                     let ratio = (p.precipitation_mm / max_p).clamp(0.0, 1.0);
                     let idx = ((ratio * (bar_chars.len() as f64 - 1.0)).round() as usize)
                         .min(bar_chars.len() - 1);
-                    bar_chars[idx]
+                    let color = crate::render::color::precipitation_color(p.precipitation_mm)
+                        .unwrap_or(theme::RAIN);
+                    Span::styled(bar_chars[idx].to_string(), Style::default().fg(color))
                 }
             })
             .collect();
         let label = s
             .precip_amount_label
             .replace("{:.1}", &format!("{:.1}", max_p));
-        (bars, label)
+        (spans, label)
     } else if has_pop {
         // 降水確率 (0-100%)
-        let bars: String = points
+        let spans: Vec<Span> = points
             .iter()
             .map(|p| {
                 let v = p.precipitation_prob_pct.unwrap_or(0.0);
                 if v <= 0.0 {
-                    ' '
+                    Span::raw(" ")
                 } else {
                     let ratio = (v / 100.0).clamp(0.0, 1.0);
                     let idx = ((ratio * (bar_chars.len() as f64 - 1.0)).round() as usize)
                         .min(bar_chars.len() - 1);
-                    bar_chars[idx]
+                    Span::styled(bar_chars[idx].to_string(), Style::default().fg(theme::RAIN))
                 }
             })
             .collect();
-        (bars, s.precip_prob_label.to_string())
+        (spans, s.precip_prob_label.to_string())
     } else {
-        (" ".repeat(points.len()), s.no_precip_data.to_string())
+        (
+            vec![Span::raw(" ".repeat(points.len()))],
+            s.no_precip_data.to_string(),
+        )
     };
 
-    let bar_line = Line::from(Span::styled(bars, Style::default().fg(theme::RAIN)));
+    let bar_line = Line::from(bar_spans);
     let label = Line::from(Span::styled(label_text, Style::default().fg(theme::SUBTLE)));
     let p = Paragraph::new(vec![bar_line, label]);
     f.render_widget(p, split[1]);

--- a/src/ui/hourly_list.rs
+++ b/src/ui/hourly_list.rs
@@ -1,7 +1,7 @@
 // 時間ごと予報リスト（Yahoo 天気風の縦並び）
 //
 // 1 行 = 1 時間。時刻・アイコン・気温・降水確率を並べる。
-// パネル高さに収まる行数だけ表示する。
+// 現在時刻の行から表示を始め、パネル幅が広いときは複数カラムで埋める。
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -12,6 +12,9 @@ use ratatui::widgets::Paragraph;
 use super::theme;
 use super::titled_block;
 use crate::app::AppState;
+
+/// 1 カラムの幅（行の内容 + 余白）
+const COL_W: u16 = 26;
 
 pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
     let s = crate::i18n::strings(state.config.ui.language);
@@ -34,27 +37,124 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
         return;
     }
 
-    let take = (inner.height as usize).min(state.hourly.len()).min(48);
+    use chrono::Datelike;
 
-    for p in state.hourly.iter().take(take) {
-        let time = p.time.format("%H:%M").to_string();
-        let temp = format!("{:>3.0}°C", p.temperature_c);
-        let rain = match (p.precipitation_mm, p.precipitation_prob_pct) {
-            (mm, _) if mm >= 0.1 => format!("{:>4.1}mm", mm),
-            (_, Some(pop)) if pop > 0.0 => format!("{:>3.0}%  ", pop),
-            _ => "  -    ".to_string(),
+    // 現在時刻を含む時間帯からスタート（過去の行は出さない）
+    let now = chrono::Local::now();
+    let start = state
+        .hourly
+        .iter()
+        .position(|p| p.time + chrono::Duration::hours(1) > now)
+        .unwrap_or(0);
+
+    // パネル幅に収まるカラム数（最低 1）。行数はカラム数 × 高さまで。
+    let ncols = ((inner.width / COL_W).max(1)) as usize;
+    let capacity = ncols * inner.height as usize;
+
+    let mut prev_day: Option<u32> = None;
+    for (i, p) in state.hourly.iter().enumerate().skip(start) {
+        if lines.len() >= capacity {
+            break;
+        }
+
+        // 日付が変わったら区切り線を入れる（先頭行は今日なので省略）
+        let day = p.time.day();
+        if let Some(prev) = prev_day {
+            if prev != day && lines.len() + 1 < capacity {
+                let label = p.time.format(" %m/%d (%a) ").to_string();
+                let pad = (COL_W as usize)
+                    .saturating_sub(unicode_width::UnicodeWidthStr::width(label.as_str()) + 2)
+                    / 2;
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "{}{}{}",
+                        "─".repeat(pad.max(2)),
+                        label,
+                        "─".repeat(pad.max(2))
+                    ),
+                    Style::default().fg(theme::BORDER),
+                )));
+            }
+        }
+        prev_day = Some(day);
+        if lines.len() >= capacity {
+            break;
+        }
+
+        let is_now = i == start;
+        let row_bg = if is_now {
+            Style::default().bg(theme::HIGHLIGHT_BG)
+        } else {
+            Style::default()
         };
-        lines.push(Line::from(vec![
-            Span::styled(format!(" {} ", time), Style::default().fg(theme::SUBTLE)),
+
+        let time = p.time.format("%H:%M").to_string();
+        // 降水: 強度に応じた色のミニバー + 数値
+        let bar_chars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+        let (rain_bar, rain_text, rain_color) = match (p.precipitation_mm, p.precipitation_prob_pct)
+        {
+            (mm, _) if mm >= 0.1 => {
+                // 16mm/h を最大としてバー高さに変換（それ以上は飽和）
+                let ratio = (mm / 16.0).clamp(0.0, 1.0);
+                let idx = 1
+                    + ((ratio * (bar_chars.len() as f64 - 2.0)).round() as usize)
+                        .min(bar_chars.len() - 2);
+                let color = crate::render::color::precipitation_color(mm).unwrap_or(theme::RAIN);
+                (bar_chars[idx], format!("{:>4.1}mm", mm), color)
+            }
+            (_, Some(pop)) if pop > 0.0 => {
+                let ratio = (pop / 100.0).clamp(0.0, 1.0);
+                let idx = 1
+                    + ((ratio * (bar_chars.len() as f64 - 2.0)).round() as usize)
+                        .min(bar_chars.len() - 2);
+                (bar_chars[idx], format!("{:>4.0}% ", pop), theme::RAIN)
+            }
+            _ => (' ', "   -  ".to_string(), theme::SUBTLE),
+        };
+
+        let mut spans = vec![
+            Span::styled(if is_now { "▌" } else { " " }, row_bg.fg(theme::ACCENT)),
+            Span::styled(
+                format!("{} ", time),
+                if is_now {
+                    row_bg.fg(theme::FG).add_modifier(Modifier::BOLD)
+                } else {
+                    row_bg.fg(theme::SUBTLE)
+                },
+            ),
             Span::styled(
                 format!("{}  ", p.icon.symbol()),
-                Style::default().add_modifier(Modifier::BOLD),
+                row_bg.add_modifier(Modifier::BOLD),
             ),
-            Span::styled(format!("{:>6}", temp), Style::default().fg(theme::TEMP)),
-            Span::raw("  "),
-            Span::styled(rain, Style::default().fg(theme::RAIN)),
-        ]));
+            Span::styled(
+                format!("{:>3.0}°", p.temperature_c),
+                row_bg.fg(theme::temp_color(p.temperature_c)),
+            ),
+            Span::styled("  ", row_bg),
+            Span::styled(rain_bar.to_string(), row_bg.fg(rain_color)),
+            Span::styled(rain_text, row_bg.fg(rain_color)),
+        ];
+        if is_now {
+            // ハイライト行は背景色をカラム右端まで伸ばす（余分はクリップされる）
+            spans.push(Span::styled(" ".repeat(COL_W as usize), row_bg));
+        }
+        lines.push(Line::from(spans));
     }
 
-    f.render_widget(Paragraph::new(lines), inner);
+    // カラムごとに分割して描画（縦に埋めてから次のカラムへ）
+    let rows = inner.height as usize;
+    for (col, chunk) in lines.chunks(rows).enumerate().take(ncols) {
+        let x = inner.x + col as u16 * COL_W;
+        let w = COL_W.min(inner.right().saturating_sub(x));
+        if w == 0 {
+            break;
+        }
+        let rect = Rect {
+            x,
+            y: inner.y,
+            width: w,
+            height: inner.height,
+        };
+        f.render_widget(Paragraph::new(chunk.to_vec()), rect);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,6 +25,23 @@ use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
 
 use crate::app::AppState;
 
+/// 左パネル（現在天気 + 週間予報）の固定幅
+const LEFT_W: u16 = 28;
+/// 右パネル（Hourly リスト）の目標幅。1カラムぶん + 枠線。
+const SIDE_TARGET_W: u16 = 30;
+
+/// 端末サイズから、レーダー合成画像に要求する理想アスペクト比（横/縦）を計算する。
+///
+/// レイアウト（左 28 + 右 30、上下のヘッダー/時間別/フッターで 10 行）を引いた
+/// レーダー領域のセル数に、フォントのピクセル比を掛けて実際の縦横比を出す。
+/// `font` はフォントのピクセルサイズ。取れないときは一般的な 1:2 とみなす。
+pub fn desired_radar_aspect(cols: u16, rows: u16, font: Option<ratatui_image::FontSize>) -> f64 {
+    let radar_w = cols.saturating_sub(LEFT_W + SIDE_TARGET_W + 2).max(10) as f64;
+    let radar_h = rows.saturating_sub(10 + 2).max(10) as f64;
+    let (fw, fh) = font.map(|f| (f.width, f.height)).unwrap_or((8, 16));
+    ((radar_w * fw as f64) / (radar_h * fh as f64)).clamp(1.0, 2.4)
+}
+
 pub fn draw(f: &mut Frame, state: &mut AppState) {
     let size = f.area();
 
@@ -57,8 +74,17 @@ pub fn draw(f: &mut Frame, state: &mut AppState) {
         1.0
     };
     let radar_h = chunks[1].height;
-    let mut radar_w_cells = ((radar_h as f32) * 2.0 * radar_aspect) as u16;
-    const LEFT_W: u16 = 28;
+    // 画像の実アスペクト比からパネル幅を決める（画像を歪ませない）。
+    // フォントのピクセル比が取れればそれを使い、無ければ 1:2 とみなす。
+    let cell_ratio = state
+        .image_picker
+        .as_ref()
+        .map(|p| {
+            let f = p.font_size();
+            f.height as f32 / f.width as f32
+        })
+        .unwrap_or(2.0);
+    let mut radar_w_cells = ((radar_h as f32) * cell_ratio * radar_aspect) as u16;
     const SIDE_MIN_W: u16 = 18;
     let total_w = chunks[1].width;
     let reserved = LEFT_W + SIDE_MIN_W;

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -28,3 +28,35 @@ pub const BORDER: Color = Color::Rgb(88, 91, 112);
 pub const TEMP: Color = Color::Rgb(243, 139, 168);
 /// 降水（青系）
 pub const RAIN: Color = Color::Rgb(137, 180, 250);
+/// 行ハイライト背景（現在時刻の行など）
+pub const HIGHLIGHT_BG: Color = Color::Rgb(49, 50, 68);
+
+/// 気温 → 色のグラデーション（寒=青系 → 暑=赤系）
+///
+/// Catppuccin の色をストップにして線形補間する。
+/// 週間予報の温度バーや気温表示の色付けに使う。
+pub fn temp_color(t: f64) -> Color {
+    const STOPS: [(f64, (u8, u8, u8)); 6] = [
+        (-5.0, (116, 199, 236)), // sapphire（寒い）
+        (5.0, (137, 220, 235)),  // sky
+        (12.0, (166, 227, 161)), // green
+        (20.0, (249, 226, 175)), // yellow
+        (27.0, (250, 179, 135)), // peach
+        (33.0, (243, 139, 168)), // red（暑い）
+    ];
+    if t <= STOPS[0].0 {
+        let (r, g, b) = STOPS[0].1;
+        return Color::Rgb(r, g, b);
+    }
+    for w in STOPS.windows(2) {
+        let (t0, c0) = w[0];
+        let (t1, c1) = w[1];
+        if t <= t1 {
+            let k = (t - t0) / (t1 - t0);
+            let lerp = |a: u8, b: u8| (a as f64 + (b as f64 - a as f64) * k).round() as u8;
+            return Color::Rgb(lerp(c0.0, c1.0), lerp(c0.1, c1.1), lerp(c0.2, c1.2));
+        }
+    }
+    let (r, g, b) = STOPS[STOPS.len() - 1].1;
+    Color::Rgb(r, g, b)
+}

--- a/src/ui/weekly.rs
+++ b/src/ui/weekly.rs
@@ -32,14 +32,32 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
     }
 
     // 縦に並べる: 1日あたり 2 行
-    //   行1: 日付 + アイコン
-    //   行2: 最高/最低 + 降水確率
+    //   行1: アイコン + 日付 + 降水確率
+    //   行2: 最低気温 ─━━━─ 最高気温 （週全体の温度レンジに対するバー）
     // パネルの高さに収まるだけ表示する。
     let max_days = ((inner.height as usize) / 2).min(7);
+
+    // 週全体の最低・最高（バーのスケール共通化のため）
+    let gmin = state
+        .daily
+        .iter()
+        .filter_map(|d| d.temp_min_c)
+        .fold(f64::INFINITY, f64::min);
+    let gmax = state
+        .daily
+        .iter()
+        .filter_map(|d| d.temp_max_c)
+        .fold(f64::NEG_INFINITY, f64::max);
+    // " 18° " + バー + " 24°" + " 40%" を引いた残りがバー幅
+    let bar_w = (inner.width as usize).saturating_sub(16).clamp(6, 16);
 
     for (i, d) in state.daily.iter().take(max_days).enumerate() {
         // 日付ヘッダ：曜日付き
         let date_label = d.date.format("%m/%d (%a)").to_string();
+        let pop = d
+            .precipitation_prob_pct
+            .map(|p| format!("{:>3.0}%", p))
+            .unwrap_or_else(|| "  - ".into());
         lines.push(Line::from(vec![
             Span::styled(
                 format!(" {} ", d.icon.symbol()),
@@ -51,28 +69,53 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
                     .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
-        ]));
-
-        // 気温と降水確率
-        let hi = d
-            .temp_max_c
-            .map(|v| format!("{:>3.0}", v))
-            .unwrap_or_else(|| "  -".into());
-        let lo = d
-            .temp_min_c
-            .map(|v| format!("{:>3.0}", v))
-            .unwrap_or_else(|| "  -".into());
-        let pop = d
-            .precipitation_prob_pct
-            .map(|p| format!("{:>3.0}%", p))
-            .unwrap_or_else(|| "  - ".into());
-
-        lines.push(Line::from(vec![
-            Span::raw("    "),
-            Span::styled(format!("{}/{}", hi, lo), Style::default().fg(theme::TEMP)),
             Span::raw("  "),
             Span::styled(pop, Style::default().fg(theme::RAIN)),
         ]));
+
+        // 温度レンジバー
+        let mut spans: Vec<Span> = Vec::new();
+        match (d.temp_min_c, d.temp_max_c) {
+            (Some(lo), Some(hi)) if gmax > gmin => {
+                spans.push(Span::styled(
+                    format!(" {:>3.0}°", lo),
+                    Style::default().fg(theme::temp_color(lo)),
+                ));
+                spans.push(Span::raw(" "));
+                for c in 0..bar_w {
+                    // セル中央の温度を求め、当日のレンジ内なら色付きの太線で描く
+                    let cell_t = gmin + (c as f64 + 0.5) / bar_w as f64 * (gmax - gmin);
+                    if cell_t >= lo && cell_t <= hi {
+                        spans.push(Span::styled(
+                            "━",
+                            Style::default().fg(theme::temp_color(cell_t)),
+                        ));
+                    } else {
+                        spans.push(Span::styled("─", Style::default().fg(theme::BORDER)));
+                    }
+                }
+                spans.push(Span::styled(
+                    format!(" {:>3.0}°", hi),
+                    Style::default().fg(theme::temp_color(hi)),
+                ));
+            }
+            _ => {
+                let hi = d
+                    .temp_max_c
+                    .map(|v| format!("{:>3.0}", v))
+                    .unwrap_or_else(|| "  -".into());
+                let lo = d
+                    .temp_min_c
+                    .map(|v| format!("{:>3.0}", v))
+                    .unwrap_or_else(|| "  -".into());
+                spans.push(Span::raw("    "));
+                spans.push(Span::styled(
+                    format!("{}/{}", hi, lo),
+                    Style::default().fg(theme::TEMP),
+                ));
+            }
+        }
+        lines.push(Line::from(spans));
 
         // 日と日の間に小さな区切り
         if i + 1 < max_days {


### PR DESCRIPTION
## Summary
- Polish all panels: temperature gradient colors (Catppuccin-based), wttr-style weekly temp range bars, Yahoo-style hourly list with current-hour highlight and day separators, intensity-colored rain mini-bars
- Fix translucent-terminal bleed-through by setting explicit bg on the hourly Chart
- Generate the radar composite image at the terminal's actual aspect ratio (up to 2.4:1) so wide terminals are fully used instead of leaving empty space on the right
  - `WeatherProvider::radar()` takes an `aspect` param; tile fetch widened to 5x3; composite is `1024*aspect x 1024` px
  - Aspect recomputed on terminal resize (refetch when drift > 0.15)
  - Panel width is still derived from the actual image aspect so `Resize::Scale` never distorts the image

## Test plan
- [x] `cargo build` / `cargo fmt` / `cargo clippy` pass
- [x] Verified in wezterm (kitty protocol): wide radar fills the terminal, no distortion
- [x] Current-hour highlight lands on the correct row
- [x] No gray band / wallpaper bleed-through in the bottom chart
- [ ] Verify on a narrow terminal (aspect clamps to 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)