### PR TITLE
fix: prevent stale radar results

### DIFF
--- a/src/api/jma.rs
+++ b/src/api/jma.rs
@@ -726,7 +726,10 @@ impl WeatherProvider for Jma {
                     let mtx = mtx as u32;
                     let mty = mty as u32;
                     map_dot_fetches.push(async move {
-                        let g = self.fetch_map_tile(rain_z, mtx, mty).await.ok();
+                        let g = self
+                            .fetch_map_tile(map_dot_tile_zoom(map_z, rain_z), mtx, mty)
+                            .await
+                            .ok();
                         ((dx, dy), g)
                     });
                     map_img_fetches.push(async move {
@@ -1343,4 +1346,20 @@ fn parse_jma_compact(s: &str) -> Result<DateTime<Local>> {
     let ndt =
         chrono::NaiveDateTime::parse_from_str(s, "%Y%m%d%H%M%S").context("validtime parse")?;
     Ok(chrono::Utc.from_utc_datetime(&ndt).with_timezone(&Local))
+}
+
+/// 背景地図ドットは `map_z` で計算したタイル座標を使うため、同じズームで取得する。
+fn map_dot_tile_zoom(map_z: u8, _rain_z: u8) -> u8 {
+    map_z
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_dot_tile_zoom;
+
+    #[test]
+    fn map_dot_tiles_use_the_map_coordinate_zoom() {
+        assert_eq!(map_dot_tile_zoom(13, 10), 13);
+        assert_eq!(map_dot_tile_zoom(8, 8), 8);
+    }
 }

--- a/src/app/fetch.rs
+++ b/src/app/fetch.rs
@@ -19,7 +19,10 @@ pub fn apply_msg(state: &mut AppState, msg: Msg) {
         Msg::Current(c) => state.current = Some(c),
         Msg::Hourly(h) => state.hourly = h,
         Msg::Daily(d) => state.daily = d,
-        Msg::Radar(r) => {
+        Msg::Radar {
+            request_id,
+            grid: r,
+        } if should_apply_radar(request_id, state.radar_request_id) => {
             // 合成画像があれば StatefulProtocol 化（描画時にパネル領域に動的フィット）
             if let (Some(picker), Some(img)) =
                 (state.image_picker.as_mut(), r.composite_image.as_ref())
@@ -30,10 +33,16 @@ pub fn apply_msg(state: &mut AppState, msg: Msg) {
             state.radar = Some(r);
             state.radar_loading = false;
         }
+        Msg::Radar { .. } => {}
         Msg::Map(m) => state.map = m,
         Msg::Error(e) => state.last_error = Some(e),
         Msg::DismissSplash => state.splash_active = false,
     }
+}
+
+/// 古い非同期取得が、新しい表示状態を上書きしないようにする。
+fn should_apply_radar(request_id: u64, latest_request_id: u64) -> bool {
+    request_id == latest_request_id
 }
 
 /// 地図データ（海岸線）を非同期にロードする。
@@ -65,6 +74,7 @@ pub fn spawn_map_load(tx: mpsc::UnboundedSender<Msg>) {
 pub fn spawn_fetch(
     provider: Arc<dyn WeatherProvider>,
     cfg: Config,
+    radar_request_id: u64,
     time_offset: i32,
     aspect: f64,
     tx: mpsc::UnboundedSender<Msg>,
@@ -122,7 +132,10 @@ pub fn spawn_fetch(
         tokio::spawn(async move {
             match p.radar(lat, lon, zoom, time_offset, aspect).await {
                 Ok(r) => {
-                    let _ = tx.send(Msg::Radar(r));
+                    let _ = tx.send(Msg::Radar {
+                        request_id: radar_request_id,
+                        grid: r,
+                    });
                 }
                 Err(e) => {
                     let _ = tx.send(Msg::Error(format!("radar: {e:#}")));
@@ -135,6 +148,7 @@ pub fn spawn_fetch(
 pub fn spawn_radar(
     provider: Arc<dyn WeatherProvider>,
     cfg: Config,
+    radar_request_id: u64,
     time_offset: i32,
     aspect: f64,
     tx: mpsc::UnboundedSender<Msg>,
@@ -145,11 +159,26 @@ pub fn spawn_radar(
     tokio::spawn(async move {
         match provider.radar(lat, lon, zoom, time_offset, aspect).await {
             Ok(r) => {
-                let _ = tx.send(Msg::Radar(r));
+                let _ = tx.send(Msg::Radar {
+                    request_id: radar_request_id,
+                    grid: r,
+                });
             }
             Err(e) => {
                 let _ = tx.send(Msg::Error(format!("radar: {e:#}")));
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_apply_radar;
+
+    #[test]
+    fn accepts_only_the_latest_radar_request() {
+        assert!(should_apply_radar(7, 7));
+        assert!(!should_apply_radar(6, 7));
+        assert!(!should_apply_radar(8, 7));
+    }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -25,13 +25,7 @@ pub fn handle_event(
         if (desired - state.radar_aspect).abs() > 0.15 && !state.radar_loading {
             state.radar_aspect = desired;
             state.radar_loading = true;
-            spawn_radar(
-                provider.clone(),
-                state.config.clone(),
-                state.radar_time_offset,
-                state.radar_aspect,
-                tx.clone(),
-            );
+            request_radar(state, provider.clone(), tx.clone());
         }
         return true;
     }
@@ -61,36 +55,18 @@ pub fn handle_event(
         KeyCode::Char('r') => {
             state.last_error = None;
             state.radar_loading = true;
-            spawn_fetch(
-                provider.clone(),
-                state.config.clone(),
-                state.radar_time_offset,
-                state.radar_aspect,
-                tx.clone(),
-            );
+            request_fetch(state, provider.clone(), tx.clone());
         }
         KeyCode::Char('+') | KeyCode::Char('=') => {
             // 13 まで上げる。z=11-13 は JMA タイル z=10 を内部でクロップして拡大表示。
             state.config.radar.zoom = (state.config.radar.zoom + 1).min(13);
             state.radar_loading = true;
-            spawn_radar(
-                provider.clone(),
-                state.config.clone(),
-                state.radar_time_offset,
-                state.radar_aspect,
-                tx.clone(),
-            );
+            request_radar(state, provider.clone(), tx.clone());
         }
         KeyCode::Char('-') | KeyCode::Char('_') => {
             state.config.radar.zoom = state.config.radar.zoom.saturating_sub(1).max(6);
             state.radar_loading = true;
-            spawn_radar(
-                provider.clone(),
-                state.config.clone(),
-                state.radar_time_offset,
-                state.radar_aspect,
-                tx.clone(),
-            );
+            request_radar(state, provider.clone(), tx.clone());
         }
         // 移動量は 0.02 度（約 2km）。タイルキャッシュが効くので連打しても軽い。
         KeyCode::Char('h') => shift_location(state, -0.02, 0.0, provider.clone(), tx.clone()),
@@ -102,25 +78,13 @@ pub fn handle_event(
             let (off_min, _) = provider.radar_offset_range();
             state.radar_time_offset = (state.radar_time_offset - 1).max(off_min);
             state.radar_loading = true;
-            spawn_radar(
-                provider.clone(),
-                state.config.clone(),
-                state.radar_time_offset,
-                state.radar_aspect,
-                tx.clone(),
-            );
+            request_radar(state, provider.clone(), tx.clone());
         }
         KeyCode::Char('.') | KeyCode::Char('>') => {
             let (_, off_max) = provider.radar_offset_range();
             state.radar_time_offset = (state.radar_time_offset + 1).min(off_max);
             state.radar_loading = true;
-            spawn_radar(
-                provider.clone(),
-                state.config.clone(),
-                state.radar_time_offset,
-                state.radar_aspect,
-                tx.clone(),
-            );
+            request_radar(state, provider.clone(), tx.clone());
         }
         // アニメーション再生 toggle。tokio interval で進行は外側で。
         KeyCode::Char('p') => {
@@ -131,13 +95,7 @@ pub fn handle_event(
             state.config.radar.map_style = state.config.radar.map_style.next();
             provider.set_map_style(state.config.radar.map_style);
             state.radar_loading = true;
-            spawn_radar(
-                provider.clone(),
-                state.config.clone(),
-                state.radar_time_offset,
-                state.radar_aspect,
-                tx.clone(),
-            );
+            request_radar(state, provider.clone(), tx.clone());
         }
         _ => return false,
     }
@@ -154,9 +112,35 @@ fn shift_location(
     state.config.location.longitude += dlon;
     state.config.location.latitude += dlat;
     state.radar_loading = true;
+    request_radar(state, provider, tx);
+}
+
+fn request_fetch(
+    state: &mut AppState,
+    provider: Arc<dyn WeatherProvider>,
+    tx: mpsc::UnboundedSender<Msg>,
+) {
+    let request_id = state.next_radar_request_id();
+    spawn_fetch(
+        provider,
+        state.config.clone(),
+        request_id,
+        state.radar_time_offset,
+        state.radar_aspect,
+        tx,
+    );
+}
+
+fn request_radar(
+    state: &mut AppState,
+    provider: Arc<dyn WeatherProvider>,
+    tx: mpsc::UnboundedSender<Msg>,
+) {
+    let request_id = state.next_radar_request_id();
     spawn_radar(
         provider,
         state.config.clone(),
+        request_id,
         state.radar_time_offset,
         state.radar_aspect,
         tx,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,6 +21,7 @@ use std::io::{Stdout, stdout};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use crossterm::cursor::Show;
 use crossterm::event::EventStream;
 use crossterm::execute;
 use crossterm::terminal::{
@@ -95,20 +96,25 @@ pub async fn run(args: Args) -> Result<()> {
         show_help: false,
         spinner_frame: 0,
         radar_loading: false,
+        radar_request_id: 0,
         radar_aspect,
         last_error: None,
         quit: false,
     };
 
     let mut terminal = setup_terminal().context("ターミナル初期化失敗")?;
+    // 途中の描画エラーでも raw mode / alternate screen を可能な限り復旧する。
+    let mut terminal_cleanup = TerminalCleanup::new();
 
     // メッセージチャンネル
     let (tx, mut rx) = mpsc::unbounded_channel::<Msg>();
 
     // 初回フェッチを spawn（天気 + 地図データ）
+    let request_id = state.next_radar_request_id();
     spawn_fetch(
         provider.clone(),
         state.config.clone(),
+        request_id,
         state.radar_time_offset,
         state.radar_aspect,
         tx.clone(),
@@ -168,7 +174,8 @@ pub async fn run(args: Args) -> Result<()> {
                     sleep(Duration::from_secs(60 * 60 * 24)).await;
                 }
             } => {
-                spawn_fetch(provider.clone(), state.config.clone(), state.radar_time_offset, state.radar_aspect, tx.clone());
+                let request_id = state.next_radar_request_id();
+                spawn_fetch(provider.clone(), state.config.clone(), request_id, state.radar_time_offset, state.radar_aspect, tx.clone());
             }
             // 雨雲アニメーション (playing 中のみ反映)
             _ = anim_tick.tick() => {
@@ -179,7 +186,8 @@ pub async fn run(args: Args) -> Result<()> {
                         state.radar_time_offset = off_min;
                     }
                     state.radar_loading = true;
-                    spawn_radar(provider.clone(), state.config.clone(), state.radar_time_offset, state.radar_aspect, tx.clone());
+                    let request_id = state.next_radar_request_id();
+                    spawn_radar(provider.clone(), state.config.clone(), request_id, state.radar_time_offset, state.radar_aspect, tx.clone());
                 }
             }
             // スピナー進行: 何かしらロード中 or splash 中なら再描画
@@ -193,18 +201,56 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     restore_terminal(&mut terminal)?;
+    terminal_cleanup.disarm();
     Ok(())
 }
 
 // === ターミナル制御 ===
 
+/// `run` がエラーで早期 return しても端末を操作可能な状態に戻すためのガード。
+struct TerminalCleanup {
+    armed: bool,
+}
+
+impl TerminalCleanup {
+    fn new() -> Self {
+        Self { armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TerminalCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // エラー処理中なので、復旧処理の失敗は元のエラーを隠さないよう握りつぶす。
+        let _ = disable_raw_mode();
+        let mut out = stdout();
+        let _ = execute!(out, LeaveAlternateScreen, Show);
+    }
+}
+
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     let mut out = stdout();
-    execute!(out, EnterAlternateScreen)?;
+    if let Err(error) = execute!(out, EnterAlternateScreen) {
+        let _ = disable_raw_mode();
+        return Err(error.into());
+    }
     let backend = CrosstermBackend::new(out);
-    let terminal = Terminal::new(backend)?;
-    Ok(terminal)
+    match Terminal::new(backend) {
+        Ok(terminal) => Ok(terminal),
+        Err(error) => {
+            let _ = disable_raw_mode();
+            let mut out = stdout();
+            let _ = execute!(out, LeaveAlternateScreen, Show);
+            Err(error.into())
+        }
+    }
 }
 
 fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -36,6 +36,8 @@ pub struct AppState {
     /// 雨雲レーダーの取得中フラグ。spawn_radar で true、Msg::Radar 受信で false。
     /// 時刻スクラブやズーム中に「いま処理中」を UI で示すために使う。
     pub radar_loading: bool,
+    /// 直近に開始したレーダー取得の世代番号。古い非同期結果を破棄するために使う。
+    pub radar_request_id: u64,
     /// 合成画像に要求するアスペクト比（横/縦）。端末サイズから計算し、
     /// ワイドターミナルではレーダーを横長にしてパネルを使い切る。
     pub radar_aspect: f64,
@@ -57,6 +59,12 @@ impl AppState {
             || self.hourly.is_empty()
             || self.daily.is_empty()
     }
+
+    /// 新しいレーダー取得を識別する世代番号を発行する。
+    pub fn next_radar_request_id(&mut self) -> u64 {
+        self.radar_request_id = self.radar_request_id.wrapping_add(1);
+        self.radar_request_id
+    }
 }
 
 // 取得結果をメインに伝えるためのメッセージ
@@ -64,7 +72,10 @@ pub enum Msg {
     Current(CurrentWeather),
     Hourly(Vec<HourlyPoint>),
     Daily(Vec<DailyPoint>),
-    Radar(RadarGrid),
+    Radar {
+        request_id: u64,
+        grid: RadarGrid,
+    },
     Map(Arc<MapData>),
     Error(String),
     /// Splash 演出を解除する（タイマー or 主要データ取得完了で送られる）


### PR DESCRIPTION
## Summary
- Ignore stale asynchronous radar responses with per-request generation IDs.
- Fetch JMA fallback map dots at the same zoom used to calculate their tile coordinates.
- Restore terminal state when setup or drawing exits with an error.

## Why
Rapid pan, zoom, scrub, or animation requests could complete out of order and display an older radar frame. The text fallback could also request map tiles at the wrong zoom.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets` (passes with existing warnings)
- [x] `cargo test --release`
- [x] `cargo build --release`
- [x] `cargo run -- --help`