### PR TITLE
chore: clean up clippy warnings

### DIFF
--- a/src/api/geocoding.rs
+++ b/src/api/geocoding.rs
@@ -63,7 +63,7 @@ pub async fn search_many(
     let url = format!(
         "https://geocoding-api.open-meteo.com/v1/search?name={}&count={}&language={}",
         urlencoding::encode(query),
-        count.max(1).min(20),
+        count.clamp(1, 20),
         lang.api_code(),
     );
     let r: Resp = client

--- a/src/api/jma.rs
+++ b/src/api/jma.rs
@@ -576,11 +576,11 @@ impl WeatherProvider for Jma {
             .unwrap_or_default();
 
         let mut out = Vec::new();
-        for i in 0..dates.len() {
+        for (i, date) in dates.iter().enumerate() {
             let code = weather_codes.get(i).cloned().unwrap_or_default();
             let condition = jma_weather_code_text(&code);
             out.push(DailyPoint {
-                date: dates[i],
+                date: *date,
                 condition: condition.to_string(),
                 icon: text_to_icon(condition),
                 temp_max_c: tmax.get(i).copied().flatten(),
@@ -594,19 +594,18 @@ impl WeatherProvider for Jma {
         if out
             .iter()
             .any(|d| d.temp_max_c.is_none() || d.temp_min_c.is_none())
+            && let Ok(om) = self.om().daily(lat, lon).await
         {
-            if let Ok(om) = self.om().daily(lat, lon).await {
-                for d in out.iter_mut() {
-                    if let Some(o) = om.iter().find(|o| o.date == d.date) {
-                        if d.temp_max_c.is_none() {
-                            d.temp_max_c = o.temp_max_c;
-                        }
-                        if d.temp_min_c.is_none() {
-                            d.temp_min_c = o.temp_min_c;
-                        }
-                        if d.precipitation_prob_pct.is_none() {
-                            d.precipitation_prob_pct = o.precipitation_prob_pct;
-                        }
+            for d in out.iter_mut() {
+                if let Some(o) = om.iter().find(|o| o.date == d.date) {
+                    if d.temp_max_c.is_none() {
+                        d.temp_max_c = o.temp_max_c;
+                    }
+                    if d.temp_min_c.is_none() {
+                        d.temp_min_c = o.temp_min_c;
+                    }
+                    if d.precipitation_prob_pct.is_none() {
+                        d.precipitation_prob_pct = o.precipitation_prob_pct;
                     }
                 }
             }
@@ -873,6 +872,7 @@ impl WeatherProvider for Jma {
 /// 5x3 タイルを地理座標系のキャンバスに貼り合わせ、
 /// ユーザー位置を中心にした view 範囲をクロップ。
 /// 雨雲は地図の上に alpha blend で重ねる。
+#[allow(clippy::too_many_arguments)]
 fn build_composite_image(
     aspect: f64,
     map_z: u8,
@@ -916,32 +916,34 @@ fn build_composite_image(
             let (_, mtx, mty) = lonlat_to_tile(v_lon, v_lat, map_z);
             let mdx = mtx as i32 - map_cx as i32;
             let mdy = mty as i32 - map_cy as i32;
-            if (-2..=2).contains(&mdx) && (-1..=1).contains(&mdy) {
-                if let Some(map) = map_imgs.get(&(mdx, mdy)) {
-                    let (lat_n_t, lon_w_t) = tile_to_lonlat(map_z, mtx, mty);
-                    let (lat_s_t, lon_e_t) = tile_to_lonlat(map_z, mtx + 1, mty + 1);
-                    let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
-                    let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
-                    base = sample_bilinear(map, fx, fy);
-                }
+            if (-2..=2).contains(&mdx)
+                && (-1..=1).contains(&mdy)
+                && let Some(map) = map_imgs.get(&(mdx, mdy))
+            {
+                let (lat_n_t, lon_w_t) = tile_to_lonlat(map_z, mtx, mty);
+                let (lat_s_t, lon_e_t) = tile_to_lonlat(map_z, mtx + 1, mty + 1);
+                let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
+                let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
+                base = sample_bilinear(map, fx, fy);
             }
             // ---- 雨雲サンプル (rain_z タイル空間) ----
             let (_, rtx, rty) = lonlat_to_tile(v_lon, v_lat, rain_z);
             let rdx = rtx as i32 - rain_cx as i32;
             let rdy = rty as i32 - rain_cy as i32;
-            if (-2..=2).contains(&rdx) && (-1..=1).contains(&rdy) {
-                if let Some(rain) = rain_imgs.get(&(rdx, rdy)) {
-                    let (lat_n_t, lon_w_t) = tile_to_lonlat(rain_z, rtx, rty);
-                    let (lat_s_t, lon_e_t) = tile_to_lonlat(rain_z, rtx + 1, rty + 1);
-                    let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
-                    let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
-                    let mmh = sample_rain_max(rain, fx, fy);
-                    if let Some((rc, gc, bc, ac)) = rain_to_yahoo(mmh) {
-                        let a = ac as f64 / 255.0;
-                        base.0[0] = blend(base.0[0], rc, a);
-                        base.0[1] = blend(base.0[1], gc, a);
-                        base.0[2] = blend(base.0[2], bc, a);
-                    }
+            if (-2..=2).contains(&rdx)
+                && (-1..=1).contains(&rdy)
+                && let Some(rain) = rain_imgs.get(&(rdx, rdy))
+            {
+                let (lat_n_t, lon_w_t) = tile_to_lonlat(rain_z, rtx, rty);
+                let (lat_s_t, lon_e_t) = tile_to_lonlat(rain_z, rtx + 1, rty + 1);
+                let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
+                let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
+                let mmh = sample_rain_max(rain, fx, fy);
+                if let Some((rc, gc, bc, ac)) = rain_to_yahoo(mmh) {
+                    let a = ac as f64 / 255.0;
+                    base.0[0] = blend(base.0[0], rc, a);
+                    base.0[1] = blend(base.0[1], gc, a);
+                    base.0[2] = blend(base.0[2], bc, a);
                 }
             }
             canvas.put_pixel(i, j, base);
@@ -1113,11 +1115,10 @@ fn sample_rain_max(img: &image::RgbaImage, fx: f64, fy: f64) -> f64 {
         let p = img.get_pixel(px, py).0;
         nowcast_color_to_mmh(p[0], p[1], p[2], p[3])
     };
-    let v = m(x0, y0) * (1.0 - dx) * (1.0 - dy)
+    m(x0, y0) * (1.0 - dx) * (1.0 - dy)
         + m(x1, y0) * dx * (1.0 - dy)
         + m(x0, y1) * (1.0 - dx) * dy
-        + m(x1, y1) * dx * dy;
-    v
+        + m(x1, y1) * dx * dy
 }
 
 /// 画像中心に "+" 形状の十字を描き込む
@@ -1150,8 +1151,8 @@ fn binarize_map_tile(img: &image::RgbaImage) -> MapDotGrid {
     // しきい値: 255 が真っ白、淡色タイルの薄いグレー線は 200 前後なので 220 で拾える
     let threshold: u32 = 220;
     let sample = 2usize;
-    for j in 0..TILE_H {
-        for i in 0..TILE_W {
+    for (j, row) in dots.iter_mut().enumerate() {
+        for (i, cell) in row.iter_mut().enumerate() {
             let mut hit = false;
             for dy in 0..sample {
                 for dx in 0..sample {
@@ -1170,7 +1171,7 @@ fn binarize_map_tile(img: &image::RgbaImage) -> MapDotGrid {
                     break;
                 }
             }
-            dots[j][i] = hit;
+            *cell = hit;
         }
     }
     dots
@@ -1181,8 +1182,8 @@ fn downsample_tile(img: &image::RgbaImage) -> TileGrid {
     let (iw, ih) = (img.width() as usize, img.height() as usize);
     let mut data = vec![vec![0.0f64; TILE_W]; TILE_H];
     let sample = 2usize;
-    for j in 0..TILE_H {
-        for i in 0..TILE_W {
+    for (j, row) in data.iter_mut().enumerate() {
+        for (i, cell) in row.iter_mut().enumerate() {
             let mut mx = 0.0f64;
             for dy in 0..sample {
                 for dx in 0..sample {
@@ -1195,7 +1196,7 @@ fn downsample_tile(img: &image::RgbaImage) -> TileGrid {
                     }
                 }
             }
-            data[j][i] = mx;
+            *cell = mx;
         }
     }
     data

--- a/src/api/open_meteo.rs
+++ b/src/api/open_meteo.rs
@@ -161,7 +161,7 @@ fn wmo_to_text(code: u32, lang: crate::i18n::Language) -> &'static str {
             66 | 67 => "凍雨",
             71 | 73 | 75 => "雪",
             77 => "霧雪",
-            80 | 81 | 82 => "にわか雨",
+            80..=82 => "にわか雨",
             85 | 86 => "にわか雪",
             95 => "雷雨",
             96 | 99 => "雷雨（雹あり）",
@@ -178,7 +178,7 @@ fn wmo_to_text(code: u32, lang: crate::i18n::Language) -> &'static str {
             66 | 67 => "Freezing rain",
             71 | 73 | 75 => "Snow",
             77 => "Snow grains",
-            80 | 81 | 82 => "Showers",
+            80..=82 => "Showers",
             85 | 86 => "Snow showers",
             95 => "Thunderstorm",
             96 | 99 => "Thunderstorm w/ hail",
@@ -585,35 +585,37 @@ fn build_composite_image_rv(
             let (_, mtx, mty) = lonlat_to_tile(v_lon, v_lat, map_z);
             let mdx = mtx as i32 - map_cx as i32;
             let mdy = mty as i32 - map_cy as i32;
-            if (-2..=2).contains(&mdx) && (-1..=1).contains(&mdy) {
-                if let Some(map) = map_imgs.get(&(mdx, mdy)) {
-                    let (lat_n_t, lon_w_t) = tile_to_lonlat(map_z, mtx, mty);
-                    let (lat_s_t, lon_e_t) = tile_to_lonlat(map_z, mtx + 1, mty + 1);
-                    let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
-                    let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
-                    base = sample_bilinear(map, fx, fy);
-                }
+            if (-2..=2).contains(&mdx)
+                && (-1..=1).contains(&mdy)
+                && let Some(map) = map_imgs.get(&(mdx, mdy))
+            {
+                let (lat_n_t, lon_w_t) = tile_to_lonlat(map_z, mtx, mty);
+                let (lat_s_t, lon_e_t) = tile_to_lonlat(map_z, mtx + 1, mty + 1);
+                let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
+                let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
+                base = sample_bilinear(map, fx, fy);
             }
             // 雨雲サンプル（RainViewer は事前色付け済み RGBA タイル）
             let (_, rtx, rty) = lonlat_to_tile(v_lon, v_lat, radar_z);
             let rdx = rtx as i32 - radar_cx as i32;
             let rdy = rty as i32 - radar_cy as i32;
-            if (-2..=2).contains(&rdx) && (-1..=1).contains(&rdy) {
-                if let Some(radar) = radar_imgs.get(&(rdx, rdy)) {
-                    let (lat_n_t, lon_w_t) = tile_to_lonlat(radar_z, rtx, rty);
-                    let (lat_s_t, lon_e_t) = tile_to_lonlat(radar_z, rtx + 1, rty + 1);
-                    let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
-                    let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
-                    let pix = sample_bilinear(radar, fx, fy);
-                    // RainViewer のタイルはフル不透明の領域が多く、そのまま重ねると
-                    // 地図を完全に覆ってしまう。0.55 倍してから合成し、雨雲が
-                    // 地図の上に半透明で乗っているように見せる。
-                    let a = (pix.0[3] as f64 / 255.0) * 0.55;
-                    if a > 0.0 {
-                        base.0[0] = blend(base.0[0], pix.0[0], a);
-                        base.0[1] = blend(base.0[1], pix.0[1], a);
-                        base.0[2] = blend(base.0[2], pix.0[2], a);
-                    }
+            if (-2..=2).contains(&rdx)
+                && (-1..=1).contains(&rdy)
+                && let Some(radar) = radar_imgs.get(&(rdx, rdy))
+            {
+                let (lat_n_t, lon_w_t) = tile_to_lonlat(radar_z, rtx, rty);
+                let (lat_s_t, lon_e_t) = tile_to_lonlat(radar_z, rtx + 1, rty + 1);
+                let fx = (v_lon - lon_w_t) / (lon_e_t - lon_w_t);
+                let fy = (lat_n_t - v_lat) / (lat_n_t - lat_s_t);
+                let pix = sample_bilinear(radar, fx, fy);
+                // RainViewer のタイルはフル不透明の領域が多く、そのまま重ねると
+                // 地図を完全に覆ってしまう。0.55 倍してから合成し、雨雲が
+                // 地図の上に半透明で乗っているように見せる。
+                let a = (pix.0[3] as f64 / 255.0) * 0.55;
+                if a > 0.0 {
+                    base.0[0] = blend(base.0[0], pix.0[0], a);
+                    base.0[1] = blend(base.0[1], pix.0[1], a);
+                    base.0[2] = blend(base.0[2], pix.0[2], a);
                 }
             }
             canvas.put_pixel(i, j, base);

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
     pub location: Location,
@@ -137,27 +137,18 @@ impl Default for RadarConfig {
     }
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            location: Location::default(),
-            ui: UiConfig::default(),
-            radar: RadarConfig::default(),
-        }
-    }
-}
-
 impl Config {
     /// 設定ディレクトリ（XDG 準拠）。
     /// 優先順位:
     ///   1. $XDG_CONFIG_HOME/termrain
     ///   2. $HOME/.config/termrain
+    ///
     /// Mac でも `~/Library/...` ではなく `~/.config/termrain` を使う（ユーザー希望）。
     pub fn dir() -> Option<PathBuf> {
-        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-            if !xdg.is_empty() {
-                return Some(PathBuf::from(xdg).join("termrain"));
-            }
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME")
+            && !xdg.is_empty()
+        {
+            return Some(PathBuf::from(xdg).join("termrain"));
         }
         std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config/termrain"))
     }
@@ -208,10 +199,10 @@ impl Config {
 /// キャッシュディレクトリ（XDG 準拠）。
 /// ログや地図タイルキャッシュなど、消えても困らないデータの置き場所。
 pub fn cache_dir() -> Option<PathBuf> {
-    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
-        if !xdg.is_empty() {
-            return Some(PathBuf::from(xdg).join("termrain"));
-        }
+    if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME")
+        && !xdg.is_empty()
+    {
+        return Some(PathBuf::from(xdg).join("termrain"));
     }
     std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache/termrain"))
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -8,19 +8,14 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Language {
     #[value(alias = "en")]
+    #[default]
     English,
     #[value(alias = "ja")]
     Japanese,
-}
-
-impl Default for Language {
-    fn default() -> Self {
-        Self::English
-    }
 }
 
 impl Language {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -28,32 +28,30 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
     let inner = block.inner(modal);
     f.render_widget(block, modal);
 
-    let mut lines: Vec<Line> = Vec::new();
-    lines.push(section(s.help_keys_section));
-    lines.push(kv(s.help_q_esc, s.help_q_esc_desc));
-    lines.push(kv("?", s.help_qmark_desc));
-    lines.push(kv("r", s.help_r_desc));
-    lines.push(kv("+ / -", s.help_zoom_desc));
-    lines.push(kv("h j k l", s.help_move_desc));
-    lines.push(kv(", / .", s.help_scrub_desc));
-    lines.push(kv("p", s.help_play_desc));
-    lines.push(kv("m", s.help_map_desc));
-    lines.push(Line::from(""));
-    lines.push(section(s.help_legend_section));
-    lines.push(legend_line());
-    lines.push(Line::from(""));
-    lines.push(section(s.help_sources_section));
-    lines.push(kv(s.help_source_rain_jp, s.help_source_rain_jp_value));
-    lines.push(kv(
-        s.help_source_rain_global,
-        s.help_source_rain_global_value,
-    ));
-    lines.push(kv(s.help_source_map, s.help_source_map_value));
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        s.help_close_hint.to_string(),
-        Style::default().fg(theme::SUBTLE),
-    )));
+    let lines: Vec<Line> = vec![
+        section(s.help_keys_section),
+        kv(s.help_q_esc, s.help_q_esc_desc),
+        kv("?", s.help_qmark_desc),
+        kv("r", s.help_r_desc),
+        kv("+ / -", s.help_zoom_desc),
+        kv("h j k l", s.help_move_desc),
+        kv(", / .", s.help_scrub_desc),
+        kv("p", s.help_play_desc),
+        kv("m", s.help_map_desc),
+        Line::from(""),
+        section(s.help_legend_section),
+        legend_line(),
+        Line::from(""),
+        section(s.help_sources_section),
+        kv(s.help_source_rain_jp, s.help_source_rain_jp_value),
+        kv(s.help_source_rain_global, s.help_source_rain_global_value),
+        kv(s.help_source_map, s.help_source_map_value),
+        Line::from(""),
+        Line::from(Span::styled(
+            s.help_close_hint.to_string(),
+            Style::default().fg(theme::SUBTLE),
+        )),
+    ];
 
     f.render_widget(Paragraph::new(lines), inner);
 }

--- a/src/ui/hourly.rs
+++ b/src/ui/hourly.rs
@@ -35,7 +35,7 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
         .position(|p| p.time + chrono::Duration::hours(1) > now)
         .unwrap_or(0);
     // 表示数は端末幅から逆算（最大 48 時間）
-    let take = (inner.width as usize).saturating_sub(4).min(48).max(8);
+    let take = (inner.width as usize).saturating_sub(4).clamp(8, 48);
     let points: Vec<&crate::api::HourlyPoint> =
         state.hourly.iter().skip(start).take(take).collect();
 

--- a/src/ui/hourly_list.rs
+++ b/src/ui/hourly_list.rs
@@ -59,22 +59,23 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
 
         // 日付が変わったら区切り線を入れる（先頭行は今日なので省略）
         let day = p.time.day();
-        if let Some(prev) = prev_day {
-            if prev != day && lines.len() + 1 < capacity {
-                let label = p.time.format(" %m/%d (%a) ").to_string();
-                let pad = (COL_W as usize)
-                    .saturating_sub(unicode_width::UnicodeWidthStr::width(label.as_str()) + 2)
-                    / 2;
-                lines.push(Line::from(Span::styled(
-                    format!(
-                        "{}{}{}",
-                        "─".repeat(pad.max(2)),
-                        label,
-                        "─".repeat(pad.max(2))
-                    ),
-                    Style::default().fg(theme::BORDER),
-                )));
-            }
+        if let Some(prev) = prev_day
+            && prev != day
+            && lines.len() + 1 < capacity
+        {
+            let label = p.time.format(" %m/%d (%a) ").to_string();
+            let pad = (COL_W as usize)
+                .saturating_sub(unicode_width::UnicodeWidthStr::width(label.as_str()) + 2)
+                / 2;
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "{}{}{}",
+                    "─".repeat(pad.max(2)),
+                    label,
+                    "─".repeat(pad.max(2))
+                ),
+                Style::default().fg(theme::BORDER),
+            )));
         }
         prev_day = Some(day);
         if lines.len() >= capacity {

--- a/src/ui/radar.rs
+++ b/src/ui/radar.rs
@@ -273,10 +273,9 @@ pub fn draw(f: &mut Frame, area: Rect, state: &mut AppState) {
             // 雨雲の下に置くため最初に描く。
             if !map_dots.is_empty() {
                 let mut pts: Vec<(f64, f64)> = Vec::new();
-                for j in 0..map_dots.len() {
-                    let row = &map_dots[j];
-                    for i in 0..row.len() {
-                        if row[i] {
+                for (j, row) in map_dots.iter().enumerate() {
+                    for (i, dot) in row.iter().enumerate() {
+                        if *dot {
                             let y = (map_dots.len() - 1 - j) as f64 + 0.5;
                             let x = i as f64 + 0.5;
                             pts.push((x, y));
@@ -332,10 +331,9 @@ pub fn draw(f: &mut Frame, area: Rect, state: &mut AppState) {
                     continue;
                 };
                 let mut pts: Vec<(f64, f64)> = Vec::new();
-                for j in 0..data.len() {
-                    let row = &data[j];
-                    for i in 0..row.len() {
-                        let v = row[i];
+                for (j, row) in data.iter().enumerate() {
+                    for (i, v) in row.iter().enumerate() {
+                        let v = *v;
                         if v >= *lo && v < *hi {
                             // grid の j=0 は北端（lat 大）。キャンバスは y 大が上なので反転不要
                             // ……ではなく、grid 内部の y は「上から下」のインデックス順なので、


### PR DESCRIPTION
## Summary
- Resolve all current Clippy warnings without changing application behavior.
- Replace index-based iteration and clamp-like expressions with idiomatic equivalents.
- Derive default implementations where appropriate and simplify nested conditions.

## Notes
- `build_composite_image` retains its explicit argument list because the rendering inputs are clearer at the call site; its focused `too_many_arguments` lint is documented locally.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release`
- [x] `cargo build --release`
- [x] `cargo run -- --help`